### PR TITLE
do not normalize datasets with too less entries

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -9,7 +9,7 @@ export function weightFunc (d, dmax, degree) {
 export function normalize (referenceArr) {
   const cutoff = Math.ceil(0.1 * referenceArr.length)
   const trimmed_arr = sort(referenceArr).slice(cutoff, referenceArr.length - cutoff)
-  const sd = math.std(trimmed_arr)
+  const sd = trimmed_arr.length > 3 ? math.std(trimmed_arr) : 1
   return function (outputArr) {
     return outputArr.map(val => val / sd)
   }

--- a/test/helpers_spec.js
+++ b/test/helpers_spec.js
@@ -44,9 +44,19 @@ describe('function normalize', function () {
     expect: [44.499, 3.266, 2.858, 2.449, 2.041, 1.633, 1.225, 0.816, 0.408, -40.825]
   }
 
+  const caseTwo = {
+    test: [109, 8, 7],
+    expect: [109, 8, 7]
+  }
+
   it('should return array divided by 10% trimmed sample deviation', function () {
     const normalizedArr = normalize(caseOne.test)(caseOne.test)
     expect(math.round(normalizedArr, 3)).to.eql(caseOne.expect)
+  })
+
+  it('should return same array if sample count is too small (lt 4)', function () {
+    const normalizedArr = normalize(caseTwo.test)(caseTwo.test)
+    expect(normalizedArr).to.eql(caseTwo.expect)
   })
 })
 


### PR DESCRIPTION
It loess is called with an array less than 4 data-points and normalization is enabled an error occurs in https://github.com/yongjun21/loess/blob/master/src/helpers.js#L12 because `math.std` can not be called with an empty array. Also it makes no sense for arrays with less than 4 entries.

This fix returns the original array is it has too little entries.